### PR TITLE
Update URL to RIPE Database

### DIFF
--- a/index.shtml
+++ b/index.shtml
@@ -19,7 +19,7 @@
 	<br>
 	from
 	<span class="mark_blue">
-		<a class="mark_blue" href="https://www.db.ripe.net/whois?searchtext=<!--#echo var="REMOTE_ADDR" -->"><!--#echo var="REMOTE_ADDR" --></a>:<!--#echo var="REMOTE_PORT" -->
+		<a class="mark_blue" href="https://apps.db.ripe.net/db-web-ui/query?searchtext=<!--#echo var="REMOTE_ADDR" -->"><!--#echo var="REMOTE_ADDR" --></a>:<!--#echo var="REMOTE_PORT" -->
 	</span>
 	<!--#if expr='v("REMOTE_HOST") = ""' -->
 		<span class="mark_red flag5<!--#echo var="REMOTE_HOST" -->">(without DNS name)</span>
@@ -29,7 +29,7 @@
 	<br>
 	to 
 	<span class="mark_blue">
-		<a class="mark_blue" href="https://www.db.ripe.net/whois?searchtext=<!--#echo var='SERVER_ADDR' -->"><!--#echo var="SERVER_ADDR" --></a>:<!--#echo var="SERVER_PORT" -->
+		<a class="mark_blue" href="https://apps.db.ripe.net/db-web-ui/query?searchtext=<!--#echo var='SERVER_ADDR' -->"><!--#echo var="SERVER_ADDR" --></a>:<!--#echo var="SERVER_PORT" -->
 	</span>
 	<span class="mark_green"><b> (<!--#echo var="SERVER_NAME" -->) </b></span>
 	<br>


### PR DESCRIPTION
The URL of the search query for IP addresses in the RIPE DB is outdated and needs to be updated.